### PR TITLE
Fix post description not showing up

### DIFF
--- a/src/templates/posts.js
+++ b/src/templates/posts.js
@@ -13,7 +13,7 @@ export default ({ pageContext: { frontmatter, html, id } }) => {
 
   return (
     <Layout>
-      <SEO title={frontmatter.title} description={frontmatter.excerpt} />
+      <SEO title={frontmatter.title} description={frontmatter.description} />
       <MainBlogTitle>{frontmatter.title}</MainBlogTitle>
       <PrePost>
         <time>


### PR DESCRIPTION
I believe this was typo. The content was empty in the post description.
`<meta name="description" content="" data-react-helmet="true">`

This small change fixes it:
`<meta name="description" content="A post about ice cream" data-react-helmet="true">`